### PR TITLE
Make fake fire use the firelike drawtype

### DIFF
--- a/mods/fake_fire/init.lua
+++ b/mods/fake_fire/init.lua
@@ -38,7 +38,7 @@ minetest.register_node("fake_fire:fake_fire", {
 		{name="fake_fire_animated.png", animation={type="vertical_frames",
 		aspect_w=16, aspect_h=16, length=1.5}},
 		},
-	drawtype = "plantlike",
+	drawtype = "firelike",
 	 -- Waving wasn't an option when this mod was written. ~ LazyJ, 2014_03_13
 	waving = 1,
 	light_source = 14,
@@ -81,7 +81,7 @@ minetest.register_node("fake_fire:smokeless_fire", {
 		{name="fake_fire_animated.png", animation={type="vertical_frames",
 		aspect_w=16, aspect_h=16, length=1.5}},
 		},
-	drawtype = "plantlike",
+	drawtype = "firelike",
 	 -- Waving wasn't an option when this mod was written. ~ LazyJ, 2014_03_13
 	waving = 1,
 	light_source = 14,
@@ -124,7 +124,7 @@ minetest.register_node("fake_fire:ice_fire", {
 		{name="ice_fire_animated.png", animation={type="vertical_frames",
 		aspect_w=16, aspect_h=16, length=1.5}},
 		},
-	drawtype = "plantlike",
+	drawtype = "firelike",
 	 -- Waving wasn't an option when this mod was written. ~ LazyJ, 2014_03_13
 	waving = 1,
 	light_source = 14,
@@ -167,7 +167,7 @@ minetest.register_node("fake_fire:smokeless_ice_fire", {
 		{name="ice_fire_animated.png", animation={type="vertical_frames",
 		aspect_w=16, aspect_h=16, length=1.5}},
 		},
-	drawtype = "plantlike",
+	drawtype = "firelike",
 	 -- Waving wasn't an option when this mod was written. ~ LazyJ, 2014_03_13
 	waving = 1,
 	light_source = 14,


### PR DESCRIPTION
Not sure what you think to this, but I've modified fake fire so that fire uses the firelike drawtype, rather than plantlike...

Before:
![screenshot_812067125](https://cloud.githubusercontent.com/assets/4390945/5363580/1baecf8a-7fd5-11e4-8e92-5b771c518385.png)
After:
![screenshot_812022731](https://cloud.githubusercontent.com/assets/4390945/5363579/1ba95460-7fd5-11e4-9713-17339c86734f.png)

(Only merge if the server uses a MT build later than https://github.com/minetest/minetest/commit/9a685a4f2ec98f64c622f87690378b1c2a084473 which I presume it does.)
