### PR TITLE
Add obdisian brick, pine tree and pine wood to stairsplus

### DIFF
--- a/mods/moreblocks/stairsplus/registrations.lua
+++ b/mods/moreblocks/stairsplus/registrations.lua
@@ -21,6 +21,9 @@ local default_nodes = { -- Default stairs/slabs/panels/microblocks:
 	"stonebrick",
 	"desert_stonebrick",
 	"sandstonebrick",
+	"obsidianbrick",
+	"pinetree",
+	"pinewood",
 }
 
 for _, name in pairs(default_nodes) do


### PR DESCRIPTION
Not updated the actual moreblocks mod, as I'm not sure what exactly has changed between your version an Calinou's.This just allows these three new nodes to be crafted into stairs plus items.
