### PR TITLE
"Fix" the craft guide search

### DIFF
--- a/mods/zcg/init.lua
+++ b/mods/zcg/init.lua
@@ -167,6 +167,8 @@ zcg.formspec = function(pn)
     if filter == "" then
         items = list
     else
+		filter = filter:lower()
+		filter = filter:gsub(" ", "_")
         items = {}
         for _, item in ipairs(list) do
             if item:find(filter, 1, true) then


### PR DESCRIPTION
Fixes #46 
I didn't remove the "Search for item strings" option, but I can do so if you want me to.
The other option "Search hidden items" doesn't seem to do anything either, so I can remove that as well if you want.