### PR TITLE
Grant admin access into shared/dropbox/cobble locked chests

### DIFF
--- a/mods/more_chests/cobble.lua
+++ b/mods/more_chests/cobble.lua
@@ -1,8 +1,10 @@
 -- Load support for translation.
 local S = minetest.get_translator("more_chests")
 
-local function has_locked_chest_privilege(meta, player)
-	if player:get_player_name() ~= meta:get_string("owner") then
+local function has_locked_chest_privilege(meta, player, pos)
+	if default.can_interact_with_node(player, pos) then
+		return true
+	elseif player:get_player_name() ~= meta:get_string("owner") then
 		return false
 	end
 	return true
@@ -60,7 +62,7 @@ minetest.register_node("more_chests:cobble", {
 	end,
 	allow_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
 		local meta = minetest.get_meta(pos)
-		if not has_locked_chest_privilege(meta, player) then
+		if not has_locked_chest_privilege(meta, player, pos) then
 			minetest.log("action", player:get_player_name()..
 					" tried to access a locked chest belonging to "..
 					meta:get_string("owner").." at "..
@@ -71,7 +73,7 @@ minetest.register_node("more_chests:cobble", {
 	end,
     allow_metadata_inventory_put = function(pos, listname, index, stack, player)
 		local meta = minetest.get_meta(pos)
-		if not has_locked_chest_privilege(meta, player) then
+		if not has_locked_chest_privilege(meta, player, pos) then
 			minetest.log("action", player:get_player_name()..
 					" tried to access a locked chest belonging to "..
 					meta:get_string("owner").." at "..
@@ -82,7 +84,7 @@ minetest.register_node("more_chests:cobble", {
 	end,
     allow_metadata_inventory_take = function(pos, listname, index, stack, player)
 		local meta = minetest.get_meta(pos)
-		if not has_locked_chest_privilege(meta, player) then
+		if not has_locked_chest_privilege(meta, player, pos) then
 			minetest.log("action", player:get_player_name()..
 					" tried to access a locked chest belonging to "..
 					meta:get_string("owner").." at "..

--- a/mods/more_chests/dropbox.lua
+++ b/mods/more_chests/dropbox.lua
@@ -2,8 +2,10 @@
 local S = minetest.get_translator("more_chests")
 local DS = minetest.get_translator("default")
 
-local function has_locked_chest_privilege(meta, player)
-	if player:get_player_name() ~= meta:get_string("owner") then
+local function has_locked_chest_privilege(meta, player, pos)
+	if default.can_interact_with_node(player, pos) then
+		return true
+	elseif player:get_player_name() ~= meta:get_string("owner") then
 		return false
 	end
 	return true
@@ -63,7 +65,7 @@ minetest.register_node("more_chests:dropbox", {
 	end,
 	allow_metadata_inventory_take = function(pos, listname, index, stack, player)
 		local meta = minetest.get_meta(pos)
-		if not has_locked_chest_privilege(meta, player) then
+		if not has_locked_chest_privilege(meta, player, pos) then
 			minetest.log("action", player:get_player_name()..
 					" tried to access a dropbox belonging to "..
 					meta:get_string("owner").." at "..
@@ -74,7 +76,7 @@ minetest.register_node("more_chests:dropbox", {
 	end,
 	allow_metadata_inventory_put = function(pos, listname, index, stack, player)
 		local meta = minetest.get_meta(pos)
-		if has_locked_chest_privilege(meta, player) then
+		if has_locked_chest_privilege(meta, player, pos) then
 			return stack:get_count()
 		end
 		local target = meta:get_inventory():get_list(listname)[index]

--- a/mods/more_chests/shared.lua
+++ b/mods/more_chests/shared.lua
@@ -1,13 +1,14 @@
 -- Load support for translation.
 local S = minetest.get_translator("more_chests")
 
-local function has_locked_chest_privilege(meta, player)
+local function has_locked_chest_privilege(meta, player, pos)
 	local name = player:get_player_name()
 	local shared = " "..meta:get_string("shared").." "
 	if name == meta:get_string("owner") then
 		return true
 	elseif shared:find(" "..name.." ") then
-
+		return true
+	elseif default.can_interact_with_node(player, pos) then
 		return true
 	else
 		return false
@@ -74,7 +75,7 @@ minetest.register_node("more_chests:shared", {
 	end,
 	allow_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
 		local meta = minetest.get_meta(pos)
-		if not has_locked_chest_privilege(meta, player) then
+		if not has_locked_chest_privilege(meta, player, pos) then
 			minetest.log("action", player:get_player_name()..
 					" tried to access a shared chest belonging to "..
 					meta:get_string("owner").." at "..
@@ -85,7 +86,7 @@ minetest.register_node("more_chests:shared", {
 	end,
     allow_metadata_inventory_put = function(pos, listname, index, stack, player)
 		local meta = minetest.get_meta(pos)
-		if not has_locked_chest_privilege(meta, player) then
+		if not has_locked_chest_privilege(meta, player, pos) then
 			minetest.log("action", player:get_player_name()..
 					" tried to access a shared chest belonging to "..
 					meta:get_string("owner").." at "..
@@ -96,7 +97,7 @@ minetest.register_node("more_chests:shared", {
 	end,
     allow_metadata_inventory_take = function(pos, listname, index, stack, player)
 		local meta = minetest.get_meta(pos)
-		if not has_locked_chest_privilege(meta, player) then
+		if not has_locked_chest_privilege(meta, player, pos) then
 			minetest.log("action", player:get_player_name()..
 					" tried to access a shared chest belonging to "..
 					meta:get_string("owner").." at "..


### PR DESCRIPTION
Previous change was wiped when mod was updated
Exact same as #104 
Code is unable to be separated from the mod code itself because the functions are local, so this is pretty much the only way and has to be updated everytime morechests is updated too.