### PR TITLE
Improved stairplus recipes

### DIFF
--- a/mods/craig_server/init.lua
+++ b/mods/craig_server/init.lua
@@ -2,6 +2,7 @@
 -- Server Misc Mod --
 ---------------------
 mod_storage = minetest.get_mod_storage()
+cgserver = {}
 
 -- Chat Commands
 dofile(minetest.get_modpath("craig_server").."/chatcommands.lua")
@@ -47,3 +48,6 @@ dofile(minetest.get_modpath("craig_server").."/cloud_height.lua")
 
 -- Zoom
 dofile(minetest.get_modpath("craig_server").."/zoom.lua")
+
+-- Moreblock Simplified Crafts
+dofile(minetest.get_modpath("craig_server").."/moreblocks_sim.lua")

--- a/mods/craig_server/moreblocks_sim.lua
+++ b/mods/craig_server/moreblocks_sim.lua
@@ -1,0 +1,306 @@
+cgserver.register_simple_recipes = function(category, alternate, modname, subname, recipeitem)
+	if category == "micro" and alternate == "" then
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":micro_" .. subname .. "_1"},
+		})
+
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":panel_" .. subname .. "_1"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":micro_" .. subname .. "_2"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":panel_" .. subname .. "_2"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":micro_" .. subname .. "_4"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":panel_" .. subname .. "_4"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":micro_" .. subname .. ""},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe = {modname .. ":panel_" .. subname .. ""},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe = {modname .. ":micro_" .. subname .. "_12"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 3",
+			recipe = {modname .. ":panel_" .. subname .. "_12"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe = {modname .. ":micro_" .. subname .. "_14"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 4",
+			recipe = {modname .. ":panel_" .. subname .. "_14"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe = {modname .. ":micro_" .. subname .. "_15"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 4",
+			recipe = {modname .. ":panel_" .. subname .. "_15"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 5",
+			recipe = {modname .. ":stair_" .. subname .. "_outer"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 6",
+			recipe = {modname .. ":stair_" .. subname .. ""},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 7",
+			recipe = {modname .. ":stair_" .. subname .. "_inner"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":slab_" .. subname .. "_1"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":slab_" .. subname .. "_2"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe = {modname .. ":slab_" .. subname .. "_quarter"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 4",
+			recipe = {modname .. ":slab_" .. subname .. ""},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 6",
+			recipe = {modname .. ":slab_" .. subname .. "_three_quarter"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 7",
+			recipe = {modname .. ":slab_" .. subname .. "_14"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 8",
+			recipe = {modname .. ":slab_" .. subname .. "_15"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":slab_" .. subname .. "_two_sides"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe = {modname .. ":slab_" .. subname .. "_three_sides"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe = {modname .. ":slab_" .. subname .. "_three_sides_u"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 3",
+			recipe = {modname .. ":stair_" .. subname .. "_half"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":stair_" .. subname .. "_alt_1"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":stair_" .. subname .. "_alt_2"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe = {modname .. ":stair_" .. subname .. "_alt_4"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 4",
+			recipe = {modname .. ":stair_" .. subname .. "_alt"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 4",
+			recipe = {modname .. ":slope_" .. subname .. ""},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe = {modname .. ":slope_" .. subname .. "_half"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 6",
+			recipe = {modname .. ":slope_" .. subname .. "_half_raised"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 7",
+			recipe = {modname .. ":slope_" .. subname .. "_inner"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 3",
+			recipe = {modname .. ":slope_" .. subname .. "_inner_half"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 7",
+			recipe = {modname .. ":slope_" .. subname .. "_inner_half_raised"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 7",
+			recipe = {modname .. ":slope_" .. subname .. "_inner_cut"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 4",
+			recipe = {modname .. ":slope_" .. subname .. "_inner_cut_half"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 8",
+			recipe = {modname .. ":slope_" .. subname .. "_inner_cut_half_raised"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 3",
+			recipe = {modname .. ":slope_" .. subname .. "_outer"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe = {modname .. ":slope_" .. subname .. "_outer_half"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 6",
+			recipe = {modname .. ":slope_" .. subname .. "_outer_half_raised"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe = {modname .. ":slope_" .. subname .. "_outer_cut"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":slope_" .. subname .. "_outer_cut_half"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 3",
+			recipe = {modname .. ":slope_" .. subname .. "_outer_cut_half_raised"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 4",
+			recipe = {modname .. ":slope_" .. subname .. "_cut"},
+		})
+
+		minetest.register_craft({
+			type = "shapeless",
+			output = recipeitem,
+			recipe = {modname .. ":micro_" .. subname, modname .. ":micro_" .. subname, modname .. ":micro_" .. subname, modname .. ":micro_" .. subname, modname .. ":micro_" .. subname, modname .. ":micro_" .. subname, modname .. ":micro_" .. subname, modname .. ":micro_" .. subname},
+		})
+
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 3",
+			recipe = {modname .. ":stair_" .. subname .. "_right_half"},
+		})
+	end
+	
+	minetest.register_alias(modname .. ":micro_" .. subname .. "_bottom", modname .. ":micro_" .. subname)
+	minetest.register_alias(modname.. ":panel_" ..subname.. "_bottom", modname.. ":panel_" ..subname)
+end

--- a/mods/moreblocks/stairsplus/recipes.lua
+++ b/mods/moreblocks/stairsplus/recipes.lua
@@ -7,7 +7,8 @@ Licensed under the zlib license. See LICENSE.md for more information.
 
 
 stairsplus.register_recipes = function(category, alternate, modname, subname, recipeitem)
-	if category == "micro" and alternate == "" then
+	cgserver.register_simple_recipes(category, alternate, modname, subname, recipeitem)
+	--[[if category == "micro" and alternate == "" then
 		minetest.register_craft({
 			type = "shapeless",
 			output = modname .. ":micro_" .. subname .. " 7",
@@ -439,5 +440,5 @@ stairsplus.register_recipes = function(category, alternate, modname, subname, re
 				},
 			})
 		end
-	end
+	end]]
 end


### PR DESCRIPTION
Same as #101 
Except I moved all the changes to craig_server instead
Likewise with the morechest changes, it is difficult to make these changes separately.
However, to make future updates easier, I moved these changes into a separate function in craig_server to be called upon.
So for future updates, all that is required to be done is, comment out existing stairplus recipe + add `cgserver.register_simple_recipes(category, alternate, modname, subname, recipeitem)` inside of `mods/moreblocks/stairsplus/recipes.lua`